### PR TITLE
Deploy services at main by default

### DIFF
--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -12,7 +12,7 @@ destination:
   namespace: bl45p
 source:
   repoURL: https://github.com/epics-containers/bl45p.git
-  targetRevision: 2024.7.7
+  targetRevision: main
 
 # list of services to deploy. Each item is of the form:
 # - service: service name as it appears in K8S (statefulset/deployment name)


### PR DESCRIPTION
Deploys services that do not have a targetRevision explicitly set as the version on main in p45-services. This means tracking the version of these services can be done in one place, and that main in that repository should be kept in a working state.